### PR TITLE
#5 関連するチーム選択時にリーグ名も表示するよう調整

### DIFF
--- a/app/Tarosky/Common/UI/RelationManager.php
+++ b/app/Tarosky/Common/UI/RelationManager.php
@@ -67,6 +67,10 @@ class RelationManager extends Singleton {
 				if( $team = sk_players_team($post->ID) ){
 					$name .= sprintf( '(%s)', $team->post_title );
 				}
+			} else if( $this->input->get( 'type' ) == 'team' ) {
+				if( $league = sk_get_main_league($post->ID) ){
+					$name .= sprintf( '(%s)', $league->name );
+				}
 			}
 
 			return [

--- a/functions/common-team.php
+++ b/functions/common-team.php
@@ -117,3 +117,39 @@ function sk_get_team_by_id( $id ) {
 		return null;
 	}
 }
+
+/**
+ * チームのメインリーグを取得する
+ *
+ * @param null|int|WP_Post $team
+ *
+ * @return WP_Term|null
+ */
+function sk_get_main_league( $team = null ) {
+	// チームを取得して、なければ終了
+	$team = get_post( $team );
+	if ( ! $team || 'team' !== $team->post_type ) {
+		return null;
+	}
+	// リーグを取得し、空白もしくはエラーだったら終了。
+	$leagues = get_the_terms( $team, 'league' );
+	if ( empty( $leagues )  || is_wp_error( $leagues ) ) {
+		return null;
+	}
+	$leagues = array_values( array_filter( $leagues, function( $term ){
+		// 親投稿が存在している（海外、などの親リーグは除外）
+		return $term->parent > 0;
+	} ) );
+	// フィルターした時点で空なら返す
+	if ( empty( $leagues ) ) {
+		return null;
+	}
+	// 優先度の昇順で並び替える
+	usort( $leagues, function( WP_Term $a, WP_Term $b ) {
+		$a_order = intval( get_term_meta( $a->term_id, 'tag_priority', true ) ?: 11 );
+		$b_order = intval( get_term_meta( $b->term_id, 'tag_priority', true ) ?: 11 );
+		return $a_order - $b_order;
+	} );
+	// 優先順位の一番高いものを返す
+	return $leagues[0] ?? null;
+}


### PR DESCRIPTION
https://github.com/tarosky/sports-king/issues/5 の対応として、関連するチームの選択肢にリーグ名も表示するように調整をしてみました。

- 表示するリーグ名はチームのメインリーグのみとしている
- メインリーグの取得処理は既存の関数を移植して使用

![team-with-league](https://github.com/user-attachments/assets/e0d064f3-ab62-4002-a0b4-1ce707b23764)

