### PR TITLE
#5 関連するチームの検索結果にフィルター追加

### DIFF
--- a/app/Tarosky/Common/UI/RelationManager.php
+++ b/app/Tarosky/Common/UI/RelationManager.php
@@ -67,10 +67,6 @@ class RelationManager extends Singleton {
 				if( $team = sk_players_team($post->ID) ){
 					$name .= sprintf( '(%s)', $team->post_title );
 				}
-			} else if( $this->input->get( 'type' ) == 'team' ) {
-				if( $league = sk_get_main_league($post->ID) ){
-					$name .= sprintf( '(%s)', $league->name );
-				}
 			}
 
 			return [

--- a/app/Tarosky/Common/UI/RelationManager.php
+++ b/app/Tarosky/Common/UI/RelationManager.php
@@ -68,6 +68,7 @@ class RelationManager extends Singleton {
 					$name .= sprintf( '(%s)', $team->post_title );
 				}
 			}
+			$name = apply_filters( 'sk_relation_search_name', $name, $post, $this->input->get( 'type' ) );
 
 			return [
 				'id'   => $post->ID,

--- a/functions/common-team.php
+++ b/functions/common-team.php
@@ -117,39 +117,3 @@ function sk_get_team_by_id( $id ) {
 		return null;
 	}
 }
-
-/**
- * チームのメインリーグを取得する
- *
- * @param null|int|WP_Post $team
- *
- * @return WP_Term|null
- */
-function sk_get_main_league( $team = null ) {
-	// チームを取得して、なければ終了
-	$team = get_post( $team );
-	if ( ! $team || 'team' !== $team->post_type ) {
-		return null;
-	}
-	// リーグを取得し、空白もしくはエラーだったら終了。
-	$leagues = get_the_terms( $team, 'league' );
-	if ( empty( $leagues )  || is_wp_error( $leagues ) ) {
-		return null;
-	}
-	$leagues = array_values( array_filter( $leagues, function( $term ){
-		// 親投稿が存在している（海外、などの親リーグは除外）
-		return $term->parent > 0;
-	} ) );
-	// フィルターした時点で空なら返す
-	if ( empty( $leagues ) ) {
-		return null;
-	}
-	// 優先度の昇順で並び替える
-	usort( $leagues, function( WP_Term $a, WP_Term $b ) {
-		$a_order = intval( get_term_meta( $a->term_id, 'tag_priority', true ) ?: 11 );
-		$b_order = intval( get_term_meta( $b->term_id, 'tag_priority', true ) ?: 11 );
-		return $a_order - $b_order;
-	} );
-	// 優先順位の一番高いものを返す
-	return $leagues[0] ?? null;
-}


### PR DESCRIPTION
以前、下記 PR で関連するチーム検索時の選択肢にリーグ名も表示に加える対応を行いました。
https://github.com/tarosky/sports-king/pull/6

ただ、サイトによってリーグデータの階層の持ち方が異なったり、優先表示したいリーグの条件が違っていたりするため、
上記のようなリーグ名の加え方では、必ずしも要件に見合ったものが出ないことが分かりました。

そこで前回行った対応は取り消して、検索結果の名前にフィルターフックを追加して、
サイト毎に調整を加えられるような形に変更してみました。
