### PR TITLE
データスタジアム接続機能にSFTP接続を追加。

### DIFF
--- a/app/Tarosky/Common/Hooks/DataStudiumHooks.php
+++ b/app/Tarosky/Common/Hooks/DataStudiumHooks.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tarosky\Common\Hooks;
+
+use Tarosky\Common\Pattern\HookPattern;
+
+/**
+ * データスタジアム接続設定
+ */
+class DataStudiumHooks extends HookPattern {
+
+    /**
+     * レジスター
+     */
+	protected function register_hooks(): void {
+        add_action( 'admin_menu', [ $this, 'add_ds_screen' ], 40 );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+	}
+
+    /**
+     * データスタジアム用の設定内容
+     */
+    public function register_settings() {
+        if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+            return;
+        }
+
+        // データスタジアム接続方法
+        add_settings_section( 'ds_options', __( 'データスタジアム設定', 'sk' ), '__return_false', 'sk_ds_options' );
+        add_settings_field( 'sk_use_ftp', __( '接続方法', 'sk' ), function () {
+            $use_ftp    = get_option( 'sk_use_ftp' );
+            $ftp_checkd = $use_ftp == '1' ? 'checked' : '' ;
+            ?>
+            <div>
+                <input type='checkbox' id='sk_ds_conn_ftp' name='sk_use_ftp' value='1' <?php echo $ftp_checkd; ?> />
+                <label for='sk_ds_conn_ftp'>FTPで接続する</label>
+            </div>
+            <?php
+        }, 'sk_ds_options', 'ds_options' );
+        register_setting( 'sk_ds_options', 'sk_use_ftp' );
+    }
+
+    /**
+     * データスタジアム用の管理画面を登録する
+     *
+     * @return void
+     */
+    public function add_ds_screen() {
+        add_options_page( __( 'データスタジアム通信設定', 'sk' ), __( 'データスタジアム設定', 'sk' ), 'manage_options', 'sk_ds_options', [ $this, 'ds_options_page' ] );
+    }
+
+    /**
+     * データスタジアム用の設定ページ
+     *
+     * @return void
+     */
+    public function ds_options_page() {
+        ?>
+        <div class="wrap">
+            <h2><?php esc_html_e( 'データスタジアム通信用オプション', 'sk' ); ?></h2>
+
+            <form method="post" action="<?php echo admin_url( 'options.php' ); ?>">
+                <?php
+                settings_fields( 'sk_ds_options' );
+                do_settings_sections( 'sk_ds_options' );
+                submit_button();
+                ?>
+            </form>
+        </div>
+
+        <?php
+    }
+
+}

--- a/app/Tarosky/Common/Service/DataStadium/DataStadiumAdapterFtp.php
+++ b/app/Tarosky/Common/Service/DataStadium/DataStadiumAdapterFtp.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tarosky\Common\Service\DataStadium;
+
+/**
+ * DataStadiumのFTP接続
+ *
+ * @package Tarosky\Common\Service\DataStadium
+ *
+ */
+class DataStadiumAdapterFtp extends DataStadiumAdapterInterface {
+
+    /**
+     * コンストラクタ。接続情報を受け継ぐ。
+     *
+     * @param $set_values
+     */
+	public function __construct( $set_values ) {
+		$this->credential = $set_values['credential'];
+		$this->root_dir = $set_values['root_dir'];
+	}
+
+    /**
+     * 接続
+     *
+     * @param $port
+     * @param $timeout
+     */
+	public function connect( $port, $timeout ) {
+		try {
+			$this->conn = ftp_connect( $this->credential['host'], $port, $timeout );
+			if ( ! $this->conn ) {
+				throw new \Exception( 'FTP接続を開始できませんでした。', 500 );
+			}
+			$logged_in = ftp_login( $this->conn, $this->credential['user'], $this->credential['pass'] );
+			if ( ! $logged_in ) {
+				throw new \Exception( 'FTPへのログインに失敗しました。', 401 );
+			}
+			// PASVモードにする
+			$this->set_pasv( true );
+			// ルートに移動
+			ftp_chdir( $this->conn, $this->root_dir );
+		} catch ( \Exception $e ) {
+			$this->error = $e;
+		}
+	}
+
+	/**
+	 * ファイルリストを取得する
+	 *
+	 * @param bool $recursive Defautl false
+	 *
+	 * @return array
+	 */
+	public function get_root_list( $recursive = true ) {
+		// ルートに移動
+		if ( ftp_chdir( $this->conn, $this->root_dir ) ) {
+			// ファイルリストを取得
+			if ( $recursive ) {
+				return $this->recursive_list( '.' );
+			} else {
+				return $this->get_list( '.' );
+			}
+		} else {
+			return new \WP_Error( 500, 'ディレクトリに移動できませんでした。' );
+		}
+	}
+
+	/**
+	 * ファイルリストを取得する
+	 *
+	 * @param string $dir
+	 *
+	 * @return array
+	 */
+	protected function recursive_list( $dir ) {
+		$files = array();
+		$list  = ftp_nlist( $this->conn, $dir );
+		if ( $list ) {
+			foreach ( $list as $file ) {
+				if ( $this->has_extension( $file ) ) {
+					$files[] = $file;
+				} else {
+					$child_list = $this->recursive_list( $dir . '/' . $file );
+					if ( $child_list ) {
+						$files[] = $child_list;
+					} else {
+						$files[] = $file;
+					}
+				}
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * PASVモードの設定を行う
+	 *
+	 * @param bool $mode
+	 *
+	 * @return bool
+	 */
+	public function set_pasv( $mode = true ) {
+		return ftp_pasv( $this->conn, $mode );
+	}
+
+	/**
+	 * 指定されたディレクトリを取得する
+	 *
+	 * @param string $dir
+	 *
+	 * @return array
+	 */
+	public function get_list( $dir ) {
+		$this->move( $dir );
+		return ftp_nlist( $this->conn, '.' );
+	}
+
+	/**
+	 * 指定したディレクトリに移動する
+	 *
+	 * @param string $dir
+	 * @param bool $absolute 初期値true。falseの場合は現在のディレクトリを保つ。
+	 *
+	 * @return bool
+	 */
+	public function move( $dir, $absolute = true ) {
+		if ( $absolute ) {
+			ftp_chdir( $this->conn, $this->root_dir );
+		}
+
+		return ftp_chdir( $this->conn, $dir );
+	}
+
+	/**
+	 * ファイルを指定したパスにダウンロードする
+	 *
+	 * @param string g$local
+	 * @param string $remote
+	 * @param int $mode
+	 *
+	 * @return bool
+	 */
+	public function download( $local, $remote, $mode = FTP_ASCII ) {
+		ftp_chdir( $this->conn, $this->root_dir );
+		return ftp_get( $this->conn, $local, $remote, $mode );
+	}
+
+	/**
+	 * ファイルの最終更新時刻を取得する
+	 *
+	 * @param string $file
+	 *
+	 * @return int Unixタイムスタンプか、失敗なら-1
+	 */
+	public function get_modified_time( $file ) {
+		ftp_chdir( $this->conn, $this->root_dir );
+		return ftp_mdtm( $this->conn, $file );
+	}
+
+	/**
+	 * 接続を終了する
+	 */
+	public function close() {
+		if ( $this->conn ) {
+			ftp_close( $this->conn );
+		}
+	}
+}

--- a/app/Tarosky/Common/Service/DataStadium/DataStadiumAdapterInterface.php
+++ b/app/Tarosky/Common/Service/DataStadium/DataStadiumAdapterInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tarosky\Common\Service\DataStadium;
+
+use Tarosky\Common\Pattern\Singleton;
+
+/**
+ * FTP/SFTP接続用のインターフェイス
+ *
+ * @package Tarosky\Common\Service\DataStadium
+ */
+abstract class DataStadiumAdapterInterface extends Singleton {
+	/**
+	 * @var resource 接続情報
+	 */
+	protected $conn = null;
+
+	/**
+	 * @var null|\Exception
+	 */
+	protected $error = null;
+
+	/**
+	 * @var array 接続情報 'host', 'user', 'pass'を持つ
+	 */
+	protected $credential = array();
+
+	/**
+	 * @var string FTPのルートディレクトリ
+	 */
+	protected $root_dir = '/';
+
+	abstract function connect( $port, $timeout );
+	abstract function get_list( $dir );
+	abstract function get_root_list( $recursive = true );
+	abstract function move( $dir, $absolute = true );
+	abstract function download( $local, $remote, $mode = FTP_ASCII );
+    abstract function get_modified_time( $file );
+	abstract function close();
+
+	/**
+	 * 指定されたファイルが拡張子を持っているか否か
+	 *
+	 * @param string $file
+	 *
+	 * @return bool
+	 */
+	protected function has_extension( $file ) {
+		return (bool) preg_match( '#\.[0-9a-zA-Z]+$#', $file );
+	}
+	/**
+	 * エラーがあるか確かめる
+	 *
+	 * @return bool
+	 */
+	public function has_error() {
+		return ! is_null( $this->error );
+	}
+
+	/**
+	 * エラー文字列を出力する
+	 *
+	 * @return string
+	 */
+	public function error_message() {
+		return $this->has_error() ? $this->error->getMessage() : '';
+	}
+}

--- a/app/Tarosky/Common/Service/DataStadium/DataStadiumAdapterSftp.php
+++ b/app/Tarosky/Common/Service/DataStadium/DataStadiumAdapterSftp.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tarosky\Common\Service\DataStadium;
+
+use phpseclib3\Net\SFTP;
+/**
+ * DataStadiumのSFTP接続
+ *
+ * @package Tarosky\Common\Service\DataStadium
+ *
+ */
+class DataStadiumAdapterSftp extends DataStadiumAdapterInterface {
+
+    /**
+     * コンストラクタ。接続情報を受け継ぐ。
+     *
+     * @param $set_values
+     */
+	public function __construct( $set_values ) {
+		$this->credential = $set_values['credential'];
+		$this->root_dir = $set_values['root_dir'];
+	}
+
+    /**
+     * 接続
+     *
+     * @param $port
+     * @param $timeout
+     */
+	public function connect( $port, $timeout ) {
+		try {
+			$this->conn = new SFTP( $this->credential['host'], $port, $timeout );
+			if ( ! $this->conn ) {
+				throw new \Exception( 'SFTP接続を開始できませんでした。', 500 );
+			}
+			$logged_in = $this->conn->login( $this->credential['user'], $this->credential['pass'] );
+			if ( ! $logged_in ) {
+				throw new \Exception( 'SFTPへのログインに失敗しました。', 401 );
+			}
+			// ルートに移動
+			$this->conn->chdir( $this->root_dir );
+		} catch ( \Exception $e ) {
+			$this->error = $e;
+		}
+	}
+
+	/**
+	 * ファイルリストを取得する
+	 *
+	 * @param bool $recursive Defautl false
+	 *
+	 * @return array
+	 */
+	public function get_root_list( $recursive = true ) {
+		// ルートに移動
+		if ( $this->conn->chdir( $this->root_dir ) ) {
+			// ファイルリストを取得
+			if ( $recursive ) {
+				return $this->recursive_list( '.' );
+			} else {
+				return $this->get_list( '.' );
+			}
+		} else {
+			return new \WP_Error( 500, 'ディレクトリに移動できませんでした。' );
+		}
+	}
+
+	/**
+	 * ファイルリストを取得する
+	 *
+	 * @param string $dir
+	 *
+	 * @return array
+	 */
+	protected function recursive_list( $dir ) {
+		$files = array();
+		$list  = $this->conn->nlist( $dir );
+		if ( $list ) {
+			foreach ( $list as $file ) {
+				if ( $this->has_extension( $file ) ) {
+					$files[] = $file;
+				} else {
+					$child_list = $this->recursive_list( $dir . '/' . $file );
+					if ( $child_list ) {
+						$files[] = $child_list;
+					} else {
+						$files[] = $file;
+					}
+				}
+			}
+		}
+
+		return $files;
+	}
+
+	/**
+	 * 指定されたディレクトリを取得する
+	 *
+	 * @param string $dir
+	 *
+	 * @return array
+	 */
+	public function get_list( $dir ) {
+		$this->move( $dir );
+		return $this->conn->nlist( '.' );
+	}
+
+	/**
+	 * 指定したディレクトリに移動する
+	 *
+	 * @param string $dir
+	 * @param bool $absolute 初期値true。falseの場合は現在のディレクトリを保つ。
+	 *
+	 * @return bool
+	 */
+	public function move( $dir, $absolute = true ) {
+		if ( $absolute ) {
+			$this->conn->chdir( $this->root_dir );
+		}
+
+		return $this->conn->chdir( $dir );
+	}
+
+	/**
+	 * ファイルを指定したパスにダウンロードする
+	 *
+	 * @param string g$local
+	 * @param string $remote
+	 * @param int $mode
+	 *
+	 * @return bool
+	 */
+	public function download( $local, $remote, $mode = FTP_ASCII ) {
+		$this->conn->chdir( $this->root_dir );
+		return $this->conn->get( $remote, $local );
+	}
+
+	/**
+	 * ファイルの最終更新時刻を取得する
+	 *
+	 * @param string $file
+	 *
+	 * @return int Unixタイムスタンプか、失敗なら-1
+	 */
+	public function get_modified_time( $file ) {
+		$this->conn->chdir( $this->root_dir );
+		return $this->conn->filemtime( $file );
+	}
+
+	/**
+	 * 接続を終了する
+	 */
+	public function close() {
+		if ( $this->conn ) {
+			$this->conn->disconnect();
+		}
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "require": {
         "php": ">=8.0",
         "ext-mbstring": "*",
-        "ext-ftp": "*"
+        "ext-ftp": "*",
+        "phpseclib/phpseclib": "^3.0"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^3.0",


### PR DESCRIPTION
@fumikito 
sportkingのデータスタジアムにSFTP接続を追加しました。ご確認お願いします。

-- -- --

・DataStadiumBase.php
　元のDB接続ベース。
　接続・操作部分の中身を以下のファイルで行うようにした。
　ゲッターでftp/sftpどちらをつかうか切り分ける。（BK内の継承クラスNpbでゲッターを上書きしていたが同じコードだったのでBK側のゲッターは消しておく。） 
https://github.com/tarosky/baseballking2024/blob/main/app/Tarosky/BaseBallKing/Service/DataStadium/Npb.php#L1074C1-L1096C3
・DataStadiumAdapterInterface.php
　インターフェイス
・DataStadiumAdapterFtp.php
・DataStadiumAdapterSftp.php
　FTP/SFTPでの接続・操作。DataStadiumBaseの関数を移しているが接続だけconnect関数を新規に作った。

・DataStudiumHooks.php
　設定画面の追加。現状はFTPを使用するチェックボックスだけ。

-- -- --

問題なさそうでしたらステージングでテストを行います。