### PR TITLE
関係する選手・チームの表示をカスタマイズしやすくするために RelationManager にフィルターを追加

### DIFF
--- a/app/Tarosky/Common/UI/RelationManager.php
+++ b/app/Tarosky/Common/UI/RelationManager.php
@@ -55,6 +55,8 @@ class RelationManager extends Singleton {
 
 	/**
 	 * Parse Ajax request.
+	 *
+	 * 関係する選手・チームの検索結果の候補として表示されるデータ
 	 */
 	public function ajax() {
 		wp_send_json( array_map( function ( $post ) {
@@ -321,6 +323,16 @@ class RelationManager extends Singleton {
 								'name' => $p->post_title,
 							];
 						}
+
+						/**
+						 * 関係する選手・チーム（すでに投稿に紐づいているデータ）の表示を書き換えるためのフィルタ
+						 *
+						 * @param array      $json    関係する選手・チームのIDと名前が格納された配列 [ ['id' => $p->ID, 'name' => $p->post_title ] ]
+						 * @param string     $type    投稿タイプ名 player or team
+						 * @param int        $post_id 投稿ID
+						 */
+						$json = apply_filters( 'sk_relations_existing_data', $json, $type, $post->ID );
+
 						printf( 'window.SkRelation.%s = %s;', $type, json_encode( $json ) );
 						?>
 					</script>


### PR DESCRIPTION
## 概要

@fumikito 
先ほど口頭でご相談をさせていただいた件です。
フックを追加しました。
ご確認をよろしくお願いいたします。

## 変更内容

- 投稿に紐づいた「関係する選手・チーム」の表示名を変更するためにフックを追加

## 関連

https://tarosky.backlog.jp/view/AUTOSPORTWEB-920

## 詳細
ライブラリのソースコードを確認して、「関係する選手・チーム」の表示名は以下二つのロジックに分かれて表示されていることがわかりました。

（１）検索結果の候補の表示（ajax）
（２）投稿にすでに保存されているデータの表示
<img width="993" height="307" alt="スクリーンショット 2026-01-23 19 31 40" src="https://github.com/user-attachments/assets/7d9fe597-5367-4b70-8b25-0b54fca53c62" />


### （１）
（１）は、sports-kingの最新版にはフックが用意されていました！
: https://github.com/tarosky/sports-king/commit/e0c3e3b5636d67fbee01aabaac5e42f91f0c13a8
現在使用しているプロジェクトでは、バージョンが低くフックが存在しないので、バージョンを上げてフックを使用します。 

### （２）
（２）はフックがなかったため、本プルリクエストで追加したいと考えています。