### PR TITLE
GitHub Actionsにrelease-drafterを追加

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@fumikito 
issue #17  に対応するプルリクです。
[release-drafter](https://github.com/release-drafter/release-drafter) という便利なGitHub Actionsがあったのですね。
この機会に知ることができてよかったです。ありがとうございます！

このプルリクのマージ後に、今取り組み中のプルリクをマージして動作を検証したいです。: https://github.com/tarosky/sports-king/pull/16 
よろしくお願いします。

## 概要

- rich-taxonomy のリポジトリと全く同じファイルを2つ追加
  - https://github.com/tarosky/rich-taxonomy/blob/main/.github/workflows/release-drafter.yml
  - https://github.com/tarosky/rich-taxonomy/blob/main/.github/release-drafter.yml
  - `environment: ` は設定なし
- release の zip にまとめる処理は無し

