### PR TITLE
VOLLEYBALLKING-212 各種エラーログの修正

### DIFF
--- a/app/Tarosky/Common/UI/RelationManager.php
+++ b/app/Tarosky/Common/UI/RelationManager.php
@@ -457,24 +457,26 @@ class RelationManager extends Singleton {
 				$this->relation->set_relation( $type, $post_id, $object_ids );
 			}
 			// 試合を登録
-			$match_id = $this->input->post('match-rel-id');
-			if( 'del' === $this->input->post('match-should-delete') ){
-				// 削除
-				$this->matches->delete_post($post_id);
-			}elseif( 'new' === $match_id ){
-				// 新規作成前に事前のデータを削除
-				$this->matches->delete_post($post_id);
-				// 新規追加
-				$this->matches->add_rel(
-					$this->input->post('match-abroad'),
-					$this->input->post('match-rel-type'),
-					$post_id,
-					$this->input->post('match-block-id')
-				);
-			}else{
-				// 更新
-				$this->matches->modify($match_id, $this->input->post('match-abroad'), $this->input->post('match-rel-type'), $this->input->post('match-block-id'));
-			}
+            if ( $this->has_form( $post->post_type, 'match') ) {
+                $match_id = $this->input->post('match-rel-id');
+                if ('del' === $this->input->post('match-should-delete')) {
+                    // 削除
+                    $this->matches->delete_post($post_id);
+                } elseif ('new' === $match_id) {
+                    // 新規作成前に事前のデータを削除
+                    $this->matches->delete_post($post_id);
+                    // 新規追加
+                    $this->matches->add_rel(
+                        $this->input->post('match-abroad'),
+                        $this->input->post('match-rel-type'),
+                        $post_id,
+                        $this->input->post('match-block-id')
+                    );
+                } else {
+                    // 更新
+                    $this->matches->modify($match_id, $this->input->post('match-abroad'), $this->input->post('match-rel-type'), $this->input->post('match-block-id'));
+                }
+            }
 			// プライマリーリーグを登録
 			foreach ( [ 'player', 'league', 'team' ] as $key ) {
 				update_post_meta( $post_id, '_primary_' . $key, filter_input( INPUT_POST, 'primary-' . $key ) );


### PR DESCRIPTION
## 問題

以下のエラーログが出ている。

WordPress database error Table 'gutenberg.wp_sk_match_relationships' doesn't exist for query SHOW FULL COLUMNS FROM `wp_sk_match_relationships` made by edit_post, wp_update_post, wp_insert_post, do_action('save_post'), WP_Hook->do_action, WP_Hook->apply_filters, Tarosky\Common\UI\RelationManager->save_post, Tarosky\Common\Models\MatchRelationships->modify, Tarosky\Common\Pattern\Model->update

## 原因

関係するチーム・選手・試合を管理する「RelationManager.php」の「save_post」関数で関係する試合がない場合でも存在しない「wp_sk_match_relationships」テーブルにデータを保存しようとする。

## 対応
「has_form」関数でサポート外だったら無視をするようにする。
